### PR TITLE
fix(ci): remove duplicate rocket emoji from workflow name

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,4 @@
-name: Publish 🚀🚀
+name: Publish 🚀
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
- Simplified the workflow name by removing an extra rocket emoji.
- Enhances clarity and consistency in the GitHub Actions UI.
- No functional changes to the CI pipeline.